### PR TITLE
Multi-Arch Image with arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.12.5 as builder
+FROM golang:1.19.3 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -14,7 +14,7 @@ COPY main.go main.go
 COPY controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,6 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -o manager main.go
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
-USER nonroot:nonroot
+USER 65532:65532
 
 ENTRYPOINT ["/manager"]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= erwinvaneyk/cert-completer:latest
+IMG ?= dwsr/cert-completer:latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 
@@ -48,12 +48,12 @@ generate: controller-gen
 	./hack/generate-k8s-resources.sh
 
 # Build the docker image
-docker-build: test
-	docker build . -t ${IMG}
+docker-build:
+	docker buildx build . --tag ${IMG} --platform linux/amd64,linux/arm64 --load
 
 # Push the docker image
 docker-push:
-	docker push ${IMG}
+	docker buildx build . --tag ${IMG} --platform linux/amd64,linux/arm64 --push
 
 # find or download controller-gen
 # download controller-gen if necessary

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= dwsr/cert-completer:latest
+IMG ?= erwinvaneyk/cert-completer:latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 


### PR DESCRIPTION
Bumps to Go 1.19 and builds a multi-arch image for arm64 and amd64.